### PR TITLE
Fix startup validation warning logging

### DIFF
--- a/frontend/src/hooks/use-startup-validation.ts
+++ b/frontend/src/hooks/use-startup-validation.ts
@@ -48,7 +48,13 @@ export function useStartupValidation() {
       if (validationResult.isValid) {
         console.log(`✅ [${new Date().toISOString()}] Application initialization completed successfully`);
       } else {
-        console.warn(`⚠️ [${new Date().toISOString()}] Application initialization completed with issues:`, validationResult.issues);
+        console.warn(
+          `⚠️ [${new Date().toISOString()}] Application initialization completed with issues:`,
+          {
+            errors: validationResult.errors,
+            warnings: validationResult.warnings,
+          },
+        );
       }
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- include startup validation errors and warnings in the warning log output when initialization completes with issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8d537ab988324acc17de17a9e5985